### PR TITLE
Rather use environment variable for the include path than a static path.

### DIFF
--- a/FMEDotNetWrapperFactory/FMEDotNetWrapperFactory.vcxproj
+++ b/FMEDotNetWrapperFactory/FMEDotNetWrapperFactory.vcxproj
@@ -105,7 +105,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FMEDOTNETWRAPPERFACTORY_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ProgramW6432)\FME\FME2017\pluginbuilder\cpp;$(ProgramW6432)\FME\FME2017\fmeobjects\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(FME_HOME)\pluginbuilder\cpp;$(FME_HOME)\fmeobjects\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -137,7 +137,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FMEDOTNETWRAPPERFACTORY_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ProgramW6432)\FME\FME2017\pluginbuilder\cpp;$(ProgramW6432)\FME\FME2017\fmeobjects\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(FME_HOME)\pluginbuilder\cpp;$(FME_HOME)\fmeobjects\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ to describe your new [Custom Transformer](https://docs.safe.com/fme/html/FME_Des
 
 ## How to build
 
-* Download and install the [FME Plug-in SDK](https://knowledge.safe.com/articles/797/developing-a-new-transformer-using-the-fme-plug-in.html).
-* Open the solution file in root folder and build your desired architecture (x86 or x64).
+1. Download and install the [FME Plug-in SDK](https://knowledge.safe.com/articles/797/developing-a-new-transformer-using-the-fme-plug-in.html).
+2. Set the environment variable *FME_HOME* to the location of your FME installation with installed FME SDK.
+3. Open the solution file in root folder and build your desired architecture (x86 or x64).
 
-  The C++/CLI project defines an additional include directory to folder where the FME Plug-in SDK is located. 
-  By default, it targets to *%PROGRAMFILES%\FME\FME2017\plugins* path, you will have to change it 
-  if you have other installation path.
+  The C++/CLI project defines an additional include directory to folder where the FME Plug-in SDK is located.
+  If the build fails check whether you followed step 2.
+  
 
   ![Additional include directories](./Docs/IncludeDirectories.png)
 


### PR DESCRIPTION
For example I've installed FME not to the default location and now use an environment variable which points to the FME home.

Of course we can discuss this :wink: